### PR TITLE
Fix missing permissions in keycloak realm export

### DIFF
--- a/charts/forms-flow-idm/templates/configmap.yaml
+++ b/charts/forms-flow-idm/templates/configmap.yaml
@@ -601,7 +601,7 @@ data:
         "requiredActions" : [ ],
         "realmRoles" : [ "uma_authorization", "offline_access" ],
         "clientRoles" : {
-          "realm-management" : [ "query-users", "query-groups", "view-users" ],
+          "realm-management" : [ "query-users", "query-groups", "view-users", "view-clients" ],
           "account" : [ "view-profile", "manage-account" ]
         },
         "notBefore" : 0,

--- a/charts/forms-flow-idm/templates/configmap.yaml
+++ b/charts/forms-flow-idm/templates/configmap.yaml
@@ -282,6 +282,14 @@ data:
               "clientRole": true,
               
               "attributes": {}
+            },
+            {
+              "name": "formsflow-analytics",
+              "description": "",
+              "composite": false,
+              "clientRole": true,
+              
+              "attributes": {}
             }
           ],
           "security-admin-console": [],


### PR DESCRIPTION
First of all, thanks for the helm charts for deploying formsflow to a k8s cluster.

When testing the services after an initial deployment, the api server fails with a status code 500 and the bpm component also returns a status code 500. Somehow the bpm component also does not state out any logs with an error.

Another error in the admin tab of formsflow web is a status code 404 from the groups endpoint of the api.

Debugging the issues in the api reveals, that there are some missing roles and permissions in keycloak.

This pull request aims to add these missing roles in the realm export of keycloak, such that the initial installation will not fail.