### PR TITLE
Use external Postgres and remove hardcoded configuration

### DIFF
--- a/charts/forms-flow-admin/templates/configmap.yaml
+++ b/charts/forms-flow-admin/templates/configmap.yaml
@@ -1,9 +1,0 @@
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  labels:
-    app: {{ .Chart.Name }}
-  name: {{ .Chart.Name }}
-data:
-  DATABASE_URL: "{{tpl .Values.postgresql.url .}}"

--- a/charts/forms-flow-admin/templates/deployment.yaml
+++ b/charts/forms-flow-admin/templates/deployment.yaml
@@ -22,6 +22,24 @@ spec:
     spec:
       containers:
       - env:
+        - name: DATABASE_USERNAME
+          {{- if and .Values.postgresql.externalSecret .Values.postgresql.externalSecret.name .Values.postgresql.externalSecret.usernameKey }}
+          valueFrom:
+            secretKeyRef:
+              key: "{{ .Values.postgresql.externalSecret.usernameKey }}"
+              name: "{{ .Values.postgresql.externalSecret.name }}"
+          {{- else }}
+          value: "{{ .Values.postgresql.username }}"
+          {{- end }}
+        - name: DATABASE_PASSWORD
+          {{- if and .Values.postgresql.externalSecret .Values.postgresql.externalSecret.name .Values.postgresql.externalSecret.passwordKey }}
+          valueFrom:
+            configMapKeyRef:
+              key: {{ .Values.postgresql.externalSecret.passwordKey }}
+              name: "{{ .Values.postgresql.externalSecret.name }}"
+          {{- else }}
+          value: "{{ .Values.postgresql.password }}"
+          {{- end }}
         - name: DATABASE_NAME
           valueFrom:
             configMapKeyRef:
@@ -38,10 +56,7 @@ spec:
               key: DATABASE_SERVICE_NAME
               name: "{{ .Values.formsflow.configmap }}"
         - name: DATABASE_URL
-          valueFrom:
-            configMapKeyRef:
-              key: DATABASE_URL
-              name: "{{ .Chart.Name}}"
+          value: "postgresql://$(DATABASE_USERNAME):$(DATABASE_PASSWORD)@{{ .Values.postgresql.host }}:{{ .Values.postgresql.port }}/{{ .Chart.Name }}"
         - name: JWT_OIDC_ALGORITHMS
           valueFrom:
             configMapKeyRef:
@@ -158,5 +173,7 @@ spec:
         stdin: true
         tty: true
       restartPolicy: Always
+      {{- if .Values.formsflow.auth }}
       imagePullSecrets:
       - name: "{{ .Values.formsflow.auth }}"
+      {{- end }}

--- a/charts/forms-flow-admin/templates/deployment.yaml
+++ b/charts/forms-flow-admin/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
         - name: DATABASE_PASSWORD
           {{- if and .Values.postgresql.externalSecret .Values.postgresql.externalSecret.name .Values.postgresql.externalSecret.passwordKey }}
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: {{ .Values.postgresql.externalSecret.passwordKey }}
               name: "{{ .Values.postgresql.externalSecret.name }}"
           {{- else }}

--- a/charts/forms-flow-admin/values.yaml
+++ b/charts/forms-flow-admin/values.yaml
@@ -1,7 +1,16 @@
 ---
 Domain: #<DEFINE ME>
 postgresql:
-  url: "postgresql://postgres:postgres@forms-flow-ai-postgresql-ha-pgpool:5432/{{.Chart.Name}}"
+  host: forms-flow-ai-postgresql-ha-pgpool
+  port: 5432
+
+  username: 'postgres'
+  password: 'postgres'
+
+  externalSecret:
+    name: 
+    usernameKey: 'postgres'
+    passwordKey: 'postgres'
 
 resources:
   limits:

--- a/charts/forms-flow-ai/Chart.yaml
+++ b/charts/forms-flow-ai/Chart.yaml
@@ -5,6 +5,7 @@ dependencies:
   - name: postgresql-ha 
     repository: https://charts.bitnami.com/bitnami
     version: 10.0.9
+    condition: postgresql-ha.enabled
   - name: mongodb
     condition: mongodb.enabled 
     repository: https://charts.bitnami.com/bitnami

--- a/charts/forms-flow-ai/templates/configmap.yaml
+++ b/charts/forms-flow-ai/templates/configmap.yaml
@@ -7,7 +7,7 @@ data:
   DATABASE_NAME: {{ ternary (tpl .Values.formsflowdb.postgresql.database .) "<DEFINE_ME>" .Values.formsflowdb.postgresql.enabled | quote }}
   DATABASE_PORT: {{ ternary .Values.formsflowdb.service.ports.postgresql "<DEFINE_ME>" .Values.formsflowdb.postgresql.enabled | quote }}
   DATABASE_SERVICE_NAME: {{ ternary (tpl .Values.formsflowdb.postgresql.fullnameOverride .) "<DEFINE_ME>" .Values.formsflowdb.postgresql.enabled | quote }}
-  BPM_API_URL: https://forms-flow-bpm-{{.Release.Namespace}}.{{tpl (.Values.Domain) .}}/camunda
+  BPM_API_URL: https://{{ tpl (index .Values "forms-flow-bpm" "ingress" "hostname") .}}/camunda
   KEYCLOAK_JWT_OIDC_ALGORITHMS: "RS256"
   KEYCLOAK_JWT_OIDC_CACHING_ENABLED: "True"
   KEYCLOAK_JWT_OIDC_JWKS_CACHE_TIMEOUT: "300"
@@ -17,27 +17,27 @@ data:
   KEYCLOAK_TOKEN_URL: https://{{ tpl (index .Values "forms-flow-idm" "keycloak" "ingress" "hostname") . }}/auth/realms/{{ index .Values "forms-flow-idm" "realm" }}/protocol/openid-connect/token
   KEYCLOAK_URL: https://{{ tpl (index .Values "forms-flow-idm" "keycloak" "ingress" "hostname") . }}
   KEYCLOAK_URL_REALM: {{ index .Values "forms-flow-idm" "realm" }}
-  FORMIO_URL: https://forms-flow-forms-{{.Release.Namespace}}.{{tpl (.Values.Domain) .}}
-  FORMIO_DOMAIN: https://forms-flow-forms-{{.Release.Namespace}}.{{tpl (.Values.Domain) .}}
-  WEB_API_URL: https://forms-flow-api-{{.Release.Namespace}}.{{tpl (.Values.Domain) .}}
+  FORMIO_URL: https://{{tpl (index .Values "forms-flow-forms" "ingress" "hostname") .}}
+  FORMIO_DOMAIN: https://{{tpl (index .Values "forms-flow-forms" "ingress" "hostname") .}}
+  WEB_API_URL: https://{{tpl (index .Values "forms-flow-api" "ingress" "hostname") .}}
   MONGODB_URI:  {{ ternary (tpl "mongodb://{{ .Values.mongodb.auth.usernames | first }}:{{ .Values.mongodb.auth.passwords | first }}@{{ .Values.mongodb.service.nameOverride }}:{{ .Values.mongodb.service.ports.mongodb }}/{{ .Values.mongodb.auth.databases | first }}" .) "<DEFINE_ME>" .Values.mongodb.enabled | quote }} 
   {{- if .Values.mongodb.enabled }} 
   NODE_CONFIG: '{"mongo":"mongodb://{{ .Values.mongodb.auth.usernames | first }}:{{ .Values.mongodb.auth.passwords | first }}@{{ .Values.mongodb.service.nameOverride }}:{{ .Values.mongodb.service.ports.mongodb }}/{{ .Values.mongodb.auth.databases | first }}"}'
   {{- else }}
   NODE_CONFIG: "<DEFINE_ME>"
   {{- end }}
-  FORMSFLOW_WEB_URL: https://forms-flow-web-{{.Release.Namespace}}.{{tpl (.Values.Domain) .}}
-  FORMSFLOW_ADMIN_URL: https://forms-flow-admin-{{.Release.Namespace}}.{{tpl (.Values.Domain) .}}/api/v1
-  FORMSFLOW_ADMIN_BASE: https://forms-flow-admin-{{.Release.Namespace}}.{{tpl (.Values.Domain) .}}/api
+  FORMSFLOW_WEB_URL: https://{{tpl (index .Values "forms-flow-web" "ingress" "hostname") .}}
+  FORMSFLOW_ADMIN_URL: https://{{tpl (index .Values "forms-flow-admin" "ingress" "hostname") .}}/api/v1
+  FORMSFLOW_ADMIN_BASE: https://{{tpl (index .Values "forms-flow-admin" "ingress" "hostname") .}}/api
   MODEL_ID: "Seethal/sentiment_analysis_generic_dataset"
-  INSIGHT_API_URL: https://forms-flow-analytics-{{.Release.Namespace}}.{{tpl (.Values.Domain) .}}
+  INSIGHT_API_URL: https://{{tpl (index .Values "forms-flow-analytics" "ingress" "hostname") .}}
   KEYCLOAK_ENABLE_CLIENT_AUTH: "false"
   MULTI_TENANCY_ENABLED: "false"
-  DATA_ANALYSIS_URL:  https://forms-flow-data-analysis-{{.Release.Namespace}}.{{tpl (.Values.Domain) .}}
+  DATA_ANALYSIS_URL:  https://{{tpl (index .Values "forms-flow-data-analysis" "ingress" "hostname") .}}
   NODE_ENV: "production"
   CUSTOM_SUBMISSION_URL: ""
   CUSTOM_SUBMISSION_ENABLED: "false"
-  FORMSFLOW_DOC_API_URL: https://forms-flow-documents-api-{{.Release.Namespace}}.{{tpl (.Values.Domain) .}}
+  FORMSFLOW_DOC_API_URL: https://{{tpl (index .Values "forms-flow-documents-api" "ingress" "hostname") .}}
   DRAFT_ENABLED: "{{.Values.draft_enabled}}"
   DRAFT_POLLING_RATE: "15000"
   EXPORT_PDF_ENABLED: "{{.Values.export_pdf_enabled}}"

--- a/charts/forms-flow-ai/values.yaml
+++ b/charts/forms-flow-ai/values.yaml
@@ -8,11 +8,36 @@ formsflowdb:
   service:
     ports:
       postgresql: 5432
+
+forms-flow-api:
+  ingress:
+    hostname: forms-flow-api-{{.Release.Namespace}}.{{tpl (.Values.Domain) .}}
+
+forms-flow-admin:
+  ingress:
+    hostname: forms-flow-admin-{{.Release.Namespace}}.{{tpl (.Values.Domain) .}}
+
+forms-flow-analytics:
+  ingress:
+    hostname: forms-flow-analytics-{{.Release.Namespace}}.{{tpl (.Values.Domain) .}}
+
+forms-flow-data-analysis:
+  ingress:
+    hostname: forms-flow-data-analysis-{{.Release.Namespace}}.{{tpl (.Values.Domain) .}}
+
+forms-flow-documents-api:
+  ingress:
+    hostname: forms-flow-documents-api-{{.Release.Namespace}}.{{tpl (.Values.Domain) .}}
+
 forms-flow-bpm:
+  ingress:
+    hostname: forms-flow-bpm-{{.Release.Namespace}}.{{tpl (.Values.Domain) .}}
   clientid: "forms-flow-bpm"
   clientsecret: "786001d6-68a8-4519-903c-bc5b5a870d68"
 
 forms-flow-forms:
+  ingress:
+    hostname: forms-flow-forms-{{.Release.Namespace}}.{{tpl (.Values.Domain) .}}
   admin:
     email: "me@defineme.com"
     password: "admin"
@@ -25,6 +50,8 @@ forms-flow-idm:
 
 forms-flow-web:
   clientid: forms-flow-web
+  ingress:
+    hostname: forms-flow-web-{{.Release.Namespace}}.{{tpl (.Values.Domain) .}}
 
 forms-flow-auth:
   imagesecret: "#DEFINE_ME"
@@ -47,7 +74,7 @@ mongodb:
       - mongodb     #use the same username in initdbscript
     enabled: true
     rootUser: root
-    rootPassword: "changeme"
+    analyticsrootPassword: "changeme"
     replicaSetKey: "formsflow"
   initdbScripts:
      init-mongo.js: |

--- a/charts/forms-flow-analytics/templates/configmap.yaml
+++ b/charts/forms-flow-analytics/templates/configmap.yaml
@@ -7,6 +7,3 @@ metadata:
   name: "{{ .Chart.Name }}"
 data:
   REDASH_HOST: "{{ tpl .Values.ingress.hostname . }}"
-  REDASH_DATABASE_URL: "{{ tpl .Values.database.url . }}"
-  REDASH_DATABASE_USERNAME: "{{ .Values.database.username }}"
-

--- a/charts/forms-flow-analytics/templates/deployment.yaml
+++ b/charts/forms-flow-analytics/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
           value: "{{ .Values.postgresql.password }}"
           {{- end }}
         - name: REDASH_DATABASE_URL
-          value: postgresql://$(REDASH_DATABASE_USERNAME):$(REDASH_DATABASE_PASSWORD)@{{.Values.postgresql.host}}:{{.Values.postgresql.port}}/{{.Chart.Name}}""
+          value: "postgresql://$(REDASH_DATABASE_USERNAME):$(REDASH_DATABASE_PASSWORD)@{{.Values.postgresql.host}}:{{.Values.postgresql.port}}/{{.Chart.Name}}"
         - name: REDASH_WEB_WORKERS
           value: "4"
         - name: GUNICORN_CMD_ARGS

--- a/charts/forms-flow-analytics/templates/deployment.yaml
+++ b/charts/forms-flow-analytics/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
         - name: REDASH_DATABASE_PASSWORD
           {{- if and .Values.postgresql.externalSecret .Values.postgresql.externalSecret.name .Values.postgresql.externalSecret.passwordKey }}
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: {{ .Values.postgresql.externalSecret.passwordKey }}
               name: "{{ .Values.postgresql.externalSecret.name }}"
           {{- else }}

--- a/charts/forms-flow-analytics/templates/deployment.yaml
+++ b/charts/forms-flow-analytics/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
           value: "{{ .Values.postgresql.password }}"
           {{- end }}
         - name: REDASH_DATABASE_URL
-          value: "postgresql://$(REDASH_DATABASE_USERNAME):$(REDASH_DATABASE_PASSWORD)@{{.Values.postgresql.host}}:{{.Values.postgresql.port}}/{{.Chart.Name}}"
+          value: "postgresql://$(REDASH_DATABASE_USERNAME):$(REDASH_DATABASE_PASSWORD)@{{.Values.postgresql.host}}:{{.Values.postgresql.port}}/{{.Values.postgresql.database}}"
         - name: REDASH_WEB_WORKERS
           value: "4"
         - name: GUNICORN_CMD_ARGS
@@ -120,7 +120,7 @@ spec:
           value: "{{ .Values.postgresql.password }}"
           {{- end }}
         - name: REDASH_DATABASE_URL
-          value: "postgresql://$(REDASH_DATABASE_USERNAME):$(REDASH_DATABASE_PASSWORD)@{{.Values.postgresql.host}}:{{.Values.postgresql.port}}/{{.Chart.Name}}"
+          value: "postgresql://$(REDASH_DATABASE_USERNAME):$(REDASH_DATABASE_PASSWORD)@{{.Values.postgresql.host}}:{{.Values.postgresql.port}}/{{.Values.postgresql.database}}"
         - name: WORKERS_COUNT
           value: "2"
         image: "{{ .Values.redash.image.registry}}/{{ .Values.redash.image.repository }}:{{ .Values.redash.image.tag }}"
@@ -181,7 +181,7 @@ spec:
           value: "{{ .Values.postgresql.password }}"
           {{- end }}
         - name: REDASH_DATABASE_URL
-          value: "postgresql://$(REDASH_DATABASE_USERNAME):$(REDASH_DATABASE_PASSWORD)@{{.Values.postgresql.host}}:{{.Values.postgresql.port}}/{{.Chart.Name}}"
+          value: "postgresql://$(REDASH_DATABASE_USERNAME):$(REDASH_DATABASE_PASSWORD)@{{.Values.postgresql.host}}:{{.Values.postgresql.port}}/{{.Values.postgresql.database}}"
         - name: WORKERS_COUNT
           value: "1"
         image: "{{ .Values.redash.image.registry}}/{{ .Values.redash.image.repository }}:{{ .Values.redash.image.tag }}"
@@ -242,7 +242,7 @@ spec:
           value: "{{ .Values.postgresql.password }}"
           {{- end }}
         - name: REDASH_DATABASE_URL
-          value: "postgresql://$(REDASH_DATABASE_USERNAME):$(REDASH_DATABASE_PASSWORD)@{{.Values.postgresql.host}}:{{.Values.postgresql.port}}/{{.Chart.Name}}"
+          value: "postgresql://$(REDASH_DATABASE_USERNAME):$(REDASH_DATABASE_PASSWORD)@{{.Values.postgresql.host}}:{{.Values.postgresql.port}}/{{.Values.postgresql.database}}"
         image: "{{ .Values.redash.image.registry}}/{{ .Values.redash.image.repository }}:{{ .Values.redash.image.tag }}"
         name: "{{ .Chart.Name }}-scheduler"
         resources:
@@ -301,7 +301,7 @@ spec:
           value: "{{ .Values.postgresql.password }}"
           {{- end }}
         - name: REDASH_DATABASE_URL
-          value: "postgresql://$(REDASH_DATABASE_USERNAME):$(REDASH_DATABASE_PASSWORD)@{{.Values.postgresql.host}}:{{.Values.postgresql.port}}/{{.Chart.Name}}"
+          value: "postgresql://$(REDASH_DATABASE_USERNAME):$(REDASH_DATABASE_PASSWORD)@{{.Values.postgresql.host}}:{{.Values.postgresql.port}}/{{.Values.postgresql.database}}"
         - name: QUEUES
           value: "periodic_emails,default"
         - name: WORKERS_COUNT

--- a/charts/forms-flow-analytics/templates/deployment.yaml
+++ b/charts/forms-flow-analytics/templates/deployment.yaml
@@ -120,7 +120,7 @@ spec:
           value: "{{ .Values.postgresql.password }}"
           {{- end }}
         - name: REDASH_DATABASE_URL
-          value: postgresql://$(REDASH_DATABASE_USERNAME):$(REDASH_DATABASE_PASSWORD)@{{.Values.postgresql.host}}:{{.Values.postgresql.port}}/{{.Chart.Name}}""
+          value: "postgresql://$(REDASH_DATABASE_USERNAME):$(REDASH_DATABASE_PASSWORD)@{{.Values.postgresql.host}}:{{.Values.postgresql.port}}/{{.Chart.Name}}"
         - name: WORKERS_COUNT
           value: "2"
         image: "{{ .Values.redash.image.registry}}/{{ .Values.redash.image.repository }}:{{ .Values.redash.image.tag }}"
@@ -181,7 +181,7 @@ spec:
           value: "{{ .Values.postgresql.password }}"
           {{- end }}
         - name: REDASH_DATABASE_URL
-          value: postgresql://$(REDASH_DATABASE_USERNAME):$(REDASH_DATABASE_PASSWORD)@{{.Values.postgresql.host}}:{{.Values.postgresql.port}}/{{.Chart.Name}}""
+          value: "postgresql://$(REDASH_DATABASE_USERNAME):$(REDASH_DATABASE_PASSWORD)@{{.Values.postgresql.host}}:{{.Values.postgresql.port}}/{{.Chart.Name}}"
         - name: WORKERS_COUNT
           value: "1"
         image: "{{ .Values.redash.image.registry}}/{{ .Values.redash.image.repository }}:{{ .Values.redash.image.tag }}"
@@ -242,7 +242,7 @@ spec:
           value: "{{ .Values.postgresql.password }}"
           {{- end }}
         - name: REDASH_DATABASE_URL
-          value: postgresql://$(REDASH_DATABASE_USERNAME):$(REDASH_DATABASE_PASSWORD)@{{.Values.postgresql.host}}:{{.Values.postgresql.port}}/{{.Chart.Name}}""
+          value: "postgresql://$(REDASH_DATABASE_USERNAME):$(REDASH_DATABASE_PASSWORD)@{{.Values.postgresql.host}}:{{.Values.postgresql.port}}/{{.Chart.Name}}"
         image: "{{ .Values.redash.image.registry}}/{{ .Values.redash.image.repository }}:{{ .Values.redash.image.tag }}"
         name: "{{ .Chart.Name }}-scheduler"
         resources:
@@ -301,7 +301,7 @@ spec:
           value: "{{ .Values.postgresql.password }}"
           {{- end }}
         - name: REDASH_DATABASE_URL
-          value: postgresql://$(REDASH_DATABASE_USERNAME):$(REDASH_DATABASE_PASSWORD)@{{.Values.postgresql.host}}:{{.Values.postgresql.port}}/{{.Chart.Name}}""
+          value: "postgresql://$(REDASH_DATABASE_USERNAME):$(REDASH_DATABASE_PASSWORD)@{{.Values.postgresql.host}}:{{.Values.postgresql.port}}/{{.Chart.Name}}"
         - name: QUEUES
           value: "periodic_emails,default"
         - name: WORKERS_COUNT

--- a/charts/forms-flow-analytics/templates/deployment.yaml
+++ b/charts/forms-flow-analytics/templates/deployment.yaml
@@ -29,6 +29,26 @@ spec:
         - secretRef:
             name: "{{ .Chart.Name }}" # default redash environment variables
         env:
+        - name: REDASH_DATABASE_USERNAME
+          {{- if and .Values.postgresql.externalSecret .Values.postgresql.externalSecret.name .Values.postgresql.externalSecret.usernameKey }}
+          valueFrom:
+            secretKeyRef:
+              key: "{{ .Values.postgresql.externalSecret.usernameKey }}"
+              name: "{{ .Values.postgresql.externalSecret.name }}"
+          {{- else }}
+          value: "{{ .Values.postgresql.username }}"
+          {{- end }}
+        - name: REDASH_DATABASE_PASSWORD
+          {{- if and .Values.postgresql.externalSecret .Values.postgresql.externalSecret.name .Values.postgresql.externalSecret.passwordKey }}
+          valueFrom:
+            configMapKeyRef:
+              key: {{ .Values.postgresql.externalSecret.passwordKey }}
+              name: "{{ .Values.postgresql.externalSecret.name }}"
+          {{- else }}
+          value: "{{ .Values.postgresql.password }}"
+          {{- end }}
+        - name: REDASH_DATABASE_URL
+          value: postgresql://$(REDASH_DATABASE_USERNAME):$(REDASH_DATABASE_PASSWORD)@{{.Values.postgresql.host}}:{{.Values.postgresql.port}}/{{.Chart.Name}}""
         - name: REDASH_WEB_WORKERS
           value: "4"
         - name: GUNICORN_CMD_ARGS
@@ -81,6 +101,26 @@ spec:
         - secretRef:
             name: "{{ .Chart.Name }}" # default redash environment variables
         env: 
+        - name: REDASH_DATABASE_USERNAME
+          {{- if and .Values.postgresql.externalSecret .Values.postgresql.externalSecret.name .Values.postgresql.externalSecret.usernameKey }}
+          valueFrom:
+            secretKeyRef:
+              key: "{{ .Values.postgresql.externalSecret.usernameKey }}"
+              name: "{{ .Values.postgresql.externalSecret.name }}"
+          {{- else }}
+          value: "{{ .Values.postgresql.username }}"
+          {{- end }}
+        - name: REDASH_DATABASE_PASSWORD
+          {{- if and .Values.postgresql.externalSecret .Values.postgresql.externalSecret.name .Values.postgresql.externalSecret.passwordKey }}
+          valueFrom:
+            configMapKeyRef:
+              key: {{ .Values.postgresql.externalSecret.passwordKey }}
+              name: "{{ .Values.postgresql.externalSecret.name }}"
+          {{- else }}
+          value: "{{ .Values.postgresql.password }}"
+          {{- end }}
+        - name: REDASH_DATABASE_URL
+          value: postgresql://$(REDASH_DATABASE_USERNAME):$(REDASH_DATABASE_PASSWORD)@{{.Values.postgresql.host}}:{{.Values.postgresql.port}}/{{.Chart.Name}}""
         - name: WORKERS_COUNT
           value: "2"
         image: "{{ .Values.redash.image.registry}}/{{ .Values.redash.image.repository }}:{{ .Values.redash.image.tag }}"
@@ -122,6 +162,26 @@ spec:
         - secretRef:
             name: "{{ .Chart.Name }}" # default redash environment variables
         env:
+        - name: REDASH_DATABASE_USERNAME
+          {{- if and .Values.postgresql.externalSecret .Values.postgresql.externalSecret.name .Values.postgresql.externalSecret.usernameKey }}
+          valueFrom:
+            secretKeyRef:
+              key: "{{ .Values.postgresql.externalSecret.usernameKey }}"
+              name: "{{ .Values.postgresql.externalSecret.name }}"
+          {{- else }}
+          value: "{{ .Values.postgresql.username }}"
+          {{- end }}
+        - name: REDASH_DATABASE_PASSWORD
+          {{- if and .Values.postgresql.externalSecret .Values.postgresql.externalSecret.name .Values.postgresql.externalSecret.passwordKey }}
+          valueFrom:
+            configMapKeyRef:
+              key: {{ .Values.postgresql.externalSecret.passwordKey }}
+              name: "{{ .Values.postgresql.externalSecret.name }}"
+          {{- else }}
+          value: "{{ .Values.postgresql.password }}"
+          {{- end }}
+        - name: REDASH_DATABASE_URL
+          value: postgresql://$(REDASH_DATABASE_USERNAME):$(REDASH_DATABASE_PASSWORD)@{{.Values.postgresql.host}}:{{.Values.postgresql.port}}/{{.Chart.Name}}""
         - name: WORKERS_COUNT
           value: "1"
         image: "{{ .Values.redash.image.registry}}/{{ .Values.redash.image.repository }}:{{ .Values.redash.image.tag }}"
@@ -162,6 +222,27 @@ spec:
             name: "{{ .Chart.Name }}" # default redash environment variables
         - secretRef:
             name: "{{ .Chart.Name }}" # default redash environment variables
+        env:
+        - name: REDASH_DATABASE_USERNAME
+          {{- if and .Values.postgresql.externalSecret .Values.postgresql.externalSecret.name .Values.postgresql.externalSecret.usernameKey }}
+          valueFrom:
+            secretKeyRef:
+              key: "{{ .Values.postgresql.externalSecret.usernameKey }}"
+              name: "{{ .Values.postgresql.externalSecret.name }}"
+          {{- else }}
+          value: "{{ .Values.postgresql.username }}"
+          {{- end }}
+        - name: REDASH_DATABASE_PASSWORD
+          {{- if and .Values.postgresql.externalSecret .Values.postgresql.externalSecret.name .Values.postgresql.externalSecret.passwordKey }}
+          valueFrom:
+            configMapKeyRef:
+              key: {{ .Values.postgresql.externalSecret.passwordKey }}
+              name: "{{ .Values.postgresql.externalSecret.name }}"
+          {{- else }}
+          value: "{{ .Values.postgresql.password }}"
+          {{- end }}
+        - name: REDASH_DATABASE_URL
+          value: postgresql://$(REDASH_DATABASE_USERNAME):$(REDASH_DATABASE_PASSWORD)@{{.Values.postgresql.host}}:{{.Values.postgresql.port}}/{{.Chart.Name}}""
         image: "{{ .Values.redash.image.registry}}/{{ .Values.redash.image.repository }}:{{ .Values.redash.image.tag }}"
         name: "{{ .Chart.Name }}-scheduler"
         resources:
@@ -201,6 +282,26 @@ spec:
         - secretRef:
             name: "{{ .Chart.Name }}" # default redash environment variables
         env:
+        - name: REDASH_DATABASE_USERNAME
+          {{- if and .Values.postgresql.externalSecret .Values.postgresql.externalSecret.name .Values.postgresql.externalSecret.usernameKey }}
+          valueFrom:
+            secretKeyRef:
+              key: "{{ .Values.postgresql.externalSecret.usernameKey }}"
+              name: "{{ .Values.postgresql.externalSecret.name }}"
+          {{- else }}
+          value: "{{ .Values.postgresql.username }}"
+          {{- end }}
+        - name: REDASH_DATABASE_PASSWORD
+          {{- if and .Values.postgresql.externalSecret .Values.postgresql.externalSecret.name .Values.postgresql.externalSecret.passwordKey }}
+          valueFrom:
+            configMapKeyRef:
+              key: {{ .Values.postgresql.externalSecret.passwordKey }}
+              name: "{{ .Values.postgresql.externalSecret.name }}"
+          {{- else }}
+          value: "{{ .Values.postgresql.password }}"
+          {{- end }}
+        - name: REDASH_DATABASE_URL
+          value: postgresql://$(REDASH_DATABASE_USERNAME):$(REDASH_DATABASE_PASSWORD)@{{.Values.postgresql.host}}:{{.Values.postgresql.port}}/{{.Chart.Name}}""
         - name: QUEUES
           value: "periodic_emails,default"
         - name: WORKERS_COUNT

--- a/charts/forms-flow-analytics/templates/deployment.yaml
+++ b/charts/forms-flow-analytics/templates/deployment.yaml
@@ -113,7 +113,7 @@ spec:
         - name: REDASH_DATABASE_PASSWORD
           {{- if and .Values.postgresql.externalSecret .Values.postgresql.externalSecret.name .Values.postgresql.externalSecret.passwordKey }}
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: {{ .Values.postgresql.externalSecret.passwordKey }}
               name: "{{ .Values.postgresql.externalSecret.name }}"
           {{- else }}
@@ -174,7 +174,7 @@ spec:
         - name: REDASH_DATABASE_PASSWORD
           {{- if and .Values.postgresql.externalSecret .Values.postgresql.externalSecret.name .Values.postgresql.externalSecret.passwordKey }}
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: {{ .Values.postgresql.externalSecret.passwordKey }}
               name: "{{ .Values.postgresql.externalSecret.name }}"
           {{- else }}
@@ -235,7 +235,7 @@ spec:
         - name: REDASH_DATABASE_PASSWORD
           {{- if and .Values.postgresql.externalSecret .Values.postgresql.externalSecret.name .Values.postgresql.externalSecret.passwordKey }}
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: {{ .Values.postgresql.externalSecret.passwordKey }}
               name: "{{ .Values.postgresql.externalSecret.name }}"
           {{- else }}
@@ -294,7 +294,7 @@ spec:
         - name: REDASH_DATABASE_PASSWORD
           {{- if and .Values.postgresql.externalSecret .Values.postgresql.externalSecret.name .Values.postgresql.externalSecret.passwordKey }}
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: {{ .Values.postgresql.externalSecret.passwordKey }}
               name: "{{ .Values.postgresql.externalSecret.name }}"
           {{- else }}

--- a/charts/forms-flow-analytics/templates/secret.yaml
+++ b/charts/forms-flow-analytics/templates/secret.yaml
@@ -7,11 +7,9 @@ metadata:
   name: "{{ .Chart.Name }}"
 stringData:
   POSTGRES_HOST_AUTH_METHOD: trust
-  POSTGRES_PASSWORD: postgres
   PYTHONUNBUFFERED: "0"
-  REDASH_COOKIE_SECRET: redash-selfhosted
+  REDASH_COOKIE_SECRET: "{{ .Values.redash.config.cookie_secret }}"
   REDASH_LOG_LEVEL: INFO
   REDASH_REDIS_URL: "redis://redis-exporter:6379/0" # url of the redis database to connect to
-  REDASH_SECRET_KEY: redash-selfhosted
+  REDASH_SECRET_KEY: "{{ .Values.redash.config.secret_key }}"
   REDASH_MULTI_ORG: 'false'
-  REDASH_DATABASE_PASSWORD: "{{ .Values.database.password }}"

--- a/charts/forms-flow-analytics/values.yaml
+++ b/charts/forms-flow-analytics/values.yaml
@@ -1,14 +1,20 @@
-Domain: #<DEFINE_ME>
+Domain: foo #<DEFINE_ME>
 
-database:
-  username: postgres 
-  password: postgres
-  servicename: forms-flow-ai-postgresql-ha-pgpool
+postgresql:
+  host: forms-flow-ai-postgresql-ha-pgpool
   port: 5432
-  url: "postgresql://{{.Values.database.username}}:{{.Values.database.password}}@{{.Values.database.servicename}}:{{.Values.database.port}}/{{.Chart.Name}}"
+
+  username: postgres
+  password: postgres
+
+  externalSecret:
+    name: 
+    usernameKey: username
+    passwordKey: password
 
 formsflow:
   auth: forms-flow-ai-auth
+
 ingress:
   ingressClassName: "" 
   annotations: 
@@ -19,6 +25,7 @@ ingress:
   selfSigned: false
   extraTls:
     - {}  
+
 redis-exporter:
   exporter:
     image:  
@@ -40,14 +47,15 @@ redis-exporter:
     requests:
       cpu: 50m
       memory: 256Mi
+
 redash:
   image:
     registry: docker.io #registry to use
     repository: formsflow/redash # repoisitory for redash image  
     tag: 10.1.5 # tag of image being used
-  database:
-    password: postgres # admin password
-    url: "postgresql://postgres:postgres@forms-flow-analytics-postgresql:5432/postgres" # redash database url - i.e forms-flow-analytics-postgresql
+  config:
+    cookie_secret: 'redash-selfhosted'
+    secret_key: 'redash-selfhosted'
 
 resources:
   limits:

--- a/charts/forms-flow-api/templates/configmap.yaml
+++ b/charts/forms-flow-api/templates/configmap.yaml
@@ -1,9 +1,0 @@
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  labels:
-    app: {{ .Chart.Name }}
-  name: {{ .Chart.Name }}
-data:
-  DATABASE_URL: "{{tpl .Values.database.url .}}"

--- a/charts/forms-flow-api/templates/deployment.yaml
+++ b/charts/forms-flow-api/templates/deployment.yaml
@@ -54,7 +54,7 @@ spec:
         - name: DATABASE_PASSWORD
           {{- if and .Values.postgresql.externalSecret .Values.postgresql.externalSecret.name .Values.postgresql.externalSecret.passwordKey }}
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: {{ .Values.postgresql.externalSecret.passwordKey }}
               name: "{{ .Values.postgresql.externalSecret.name }}"
           {{- else }}

--- a/charts/forms-flow-api/templates/deployment.yaml
+++ b/charts/forms-flow-api/templates/deployment.yaml
@@ -61,10 +61,7 @@ spec:
           value: "{{ .Values.postgresql.password }}"
           {{- end }}
         - name: DATABASE_URL
-          valueFrom:
-            configMapKeyRef:
-              key: DATABASE_URL
-              name: "postgresql://$(DATABASE_USERNAME):$(DATABASE_PASSWORD)@{{ .Values.postgresql.host }}:{{ .Values.postgresql.port }}/{{ .Values.postgresql.database }}"
+          value: "postgresql://$(DATABASE_USERNAME):$(DATABASE_PASSWORD)@{{ .Values.postgresql.host }}:{{ .Values.postgresql.port }}/{{ .Values.postgresql.database }}"
         - name: JWT_OIDC_ALGORITHMS
           valueFrom:
             configMapKeyRef:

--- a/charts/forms-flow-api/templates/deployment.yaml
+++ b/charts/forms-flow-api/templates/deployment.yaml
@@ -22,11 +22,6 @@ spec:
     spec:
       containers:
       - env:
-        - name: MONGODB_URI
-          valueFrom:
-            configMapKeyRef:
-              key: MONGODB_URI
-              name: "{{ .Values.formsflow.configmap }}"
         - name: BPM_API_URL
           valueFrom:
             configMapKeyRef:
@@ -47,26 +42,29 @@ spec:
             configMapKeyRef:
               key: KEYCLOAK_TOKEN_URL
               name: "{{ .Values.formsflow.configmap }}"
-        - name: DATABASE_NAME
+        - name: DATABASE_USERNAME
+          {{- if and .Values.postgresql.externalSecret .Values.postgresql.externalSecret.name .Values.postgresql.externalSecret.usernameKey }}
+          valueFrom:
+            secretKeyRef:
+              key: "{{ .Values.postgresql.externalSecret.usernameKey }}"
+              name: "{{ .Values.postgresql.externalSecret.name }}"
+          {{- else }}
+          value: "{{ .Values.postgresql.username }}"
+          {{- end }}
+        - name: DATABASE_PASSWORD
+          {{- if and .Values.postgresql.externalSecret .Values.postgresql.externalSecret.name .Values.postgresql.externalSecret.passwordKey }}
           valueFrom:
             configMapKeyRef:
-              key: DATABASE_NAME
-              name: "{{ .Values.formsflow.configmap }}"
-        - name: DATABASE_PORT
-          valueFrom:
-            configMapKeyRef:
-              key: DATABASE_PORT
-              name: "{{ .Values.formsflow.configmap }}"
-        - name: DATABASE_SERVICE_NAME
-          valueFrom:
-            configMapKeyRef:
-              key: DATABASE_SERVICE_NAME
-              name: "{{ .Values.formsflow.configmap }}"
+              key: {{ .Values.postgresql.externalSecret.passwordKey }}
+              name: "{{ .Values.postgresql.externalSecret.name }}"
+          {{- else }}
+          value: "{{ .Values.postgresql.password }}"
+          {{- end }}
         - name: DATABASE_URL
           valueFrom:
             configMapKeyRef:
               key: DATABASE_URL
-              name: "{{ .Chart.Name }}"
+              name: "postgresql://$(DATABASE_USERNAME):$(DATABASE_PASSWORD)@{{ .Values.postgresql.host }}:{{ .Values.postgresql.port }}/{{ .Values.postgresql.database }}"
         - name: JWT_OIDC_ALGORITHMS
           valueFrom:
             configMapKeyRef:

--- a/charts/forms-flow-api/values.yaml
+++ b/charts/forms-flow-api/values.yaml
@@ -1,7 +1,20 @@
 ---
 Domain: #<DEFINE_ME>
-database:
-  url: "postgresql://postgres:postgres@forms-flow-ai-postgresql-ha-pgpool:5432/{{.Chart.Name}}"
+
+postgresql:
+  host: forms-flow-ai-postgresql-ha-pgpool
+  port: 5432
+
+  database: "forms-flow-api"
+
+  username: postgres
+  password: postgres
+
+  externalSecret:
+    name: 
+    usernameKey: username
+    passwordKey: password
+
 resources:
   limits:
     cpu: 300m
@@ -9,10 +22,12 @@ resources:
   requests:
     cpu: 200m
     memory: 512Mi
+
 formsflow:
   configmap: forms-flow-ai # name of formsflow.ai configmap
   secret: forms-flow-ai #name of formsflow.ai secret
   auth: forms-flow-ai-auth 
+
 ingress:
   ingressClassName: ""
   annotations:
@@ -24,6 +39,7 @@ ingress:
   selfSigned: false
   extraTls:
     - {}
+
 image:
   registry: docker.io
   repository: formsflow/forms-flow-webapi

--- a/charts/forms-flow-bpm/templates/configmap.yaml
+++ b/charts/forms-flow-bpm/templates/configmap.yaml
@@ -2,20 +2,14 @@
 apiVersion: v1
 data:
   APP_SECURITY_ORIGIN: "*"
-  CAMUNDA_ANALYTICS_DATABASE_SERVICE_NAME: "{{ .Values.camunda.analytics.database }}"
   CAMUNDA_APP_ROOT_LOG_FLAG: "{{ .Values.camunda.logLevel }}"
   CAMUNDA_AUTHORIZATION_FLAG: "{{ .Values.camunda.auth.enabled }}"
   CAMUNDA_AUTHORIZATION_REVOKE_CHECK_FLAG: "{{ .Values.camunda.auth.revokeCheck }}"
-  CAMUNDA_DATABASE_NAME: "{{.Values.camunda.database.name}}"
-  CAMUNDA_DATABASE_PORT: "{{.Values.camunda.database.port}}"
   CAMUNDA_FORMBUILDER_PIPELINE_USERNAME: "{{ .Values.camunda.formBuilder.username }}"
   CAMUNDA_HIKARI_CONN_TIMEOUT: "{{ .Values.camunda.hikari.timeout.connection }}"
   CAMUNDA_HIKARI_IDLE_TIMEOUT: "{{ .Values.camunda.hikari.timeout.idle }}"
   CAMUNDA_HIKARI_VALID_TIMEOUT: "{{ .Values.camunda.hikari.timeout.valid }}"
   CAMUNDA_HIKARI_MAX_POOLSIZE: "{{ .Values.camunda.hikari.poolsize.max }}"
-  CAMUNDA_JDBC_DRIVER: "{{ .Values.camunda.jdbc.driver }}"
-  CAMUNDA_JDBC_URL: "{{ tpl .Values.camunda.jdbc.url .}}"
-  CAMUNDA_JDBC_USER: "{{ .Values.camunda.jdbc.username}}"
   WAIT_FOR: " {{ .Values.waitFor }}"  
   WEBSOCKET_MESSAGE_TYPE: "{{ .Values.camunda.websocket.messageType }}"
   WEBSOCKET_SECURITY_ORIGIN: {{ ternary  (.Values.camunda.websocket.securityOrigin | quote) (randAlphaNum 6 | quote) (kindIs "string" .Values.camunda.websocket.securityOrigin) }}

--- a/charts/forms-flow-bpm/templates/deployment.yaml
+++ b/charts/forms-flow-bpm/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
         - name: CAMUNDA_JDBC_PASSWORD
           {{- if and .Values.postgresql.externalSecret .Values.postgresql.externalSecret.name .Values.postgresql.externalSecret.passwordKey }}
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               key: {{ .Values.postgresql.externalSecret.passwordKey }}
               name: "{{ .Values.postgresql.externalSecret.name }}"
           {{- else }}

--- a/charts/forms-flow-bpm/templates/deployment.yaml
+++ b/charts/forms-flow-bpm/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
         - name: CAMUNDA_DATABASE_SERVICE_NAME
           value: "{{ .Values.postgresql.host }}"
         - name: CAMUNDA_JDBC_URL
-          value: "jdbc:postgresql://@${CAMUNDA_DATABASE_SERVICE_NAME}:${CAMUNDA_DATABASE_PORT}/${CAMUNDA_DATABASE_NAME}"
+          value: "jdbc:postgresql://${CAMUNDA_DATABASE_SERVICE_NAME}:${CAMUNDA_DATABASE_PORT}/${CAMUNDA_DATABASE_NAME}"
         - name: KEYCLOAK_URL
           valueFrom:
             configMapKeyRef:

--- a/charts/forms-flow-bpm/templates/deployment.yaml
+++ b/charts/forms-flow-bpm/templates/deployment.yaml
@@ -36,21 +36,34 @@ spec:
         - secretRef:
             name: "{{ .Chart.Name }}" # bpm environment variables
         env:
+        - name: CAMUNDA_JDBC_DRIVER
+          value: "{{ .Values.postgresql.jdbcDriver }}"
+        - name: CAMUNDA_JDBC_USER
+          {{- if and .Values.postgresql.externalSecret .Values.postgresql.externalSecret.name .Values.postgresql.externalSecret.usernameKey }}
+          valueFrom:
+            secretKeyRef:
+              key: "{{ .Values.postgresql.externalSecret.usernameKey }}"
+              name: "{{ .Values.postgresql.externalSecret.name }}"
+          {{- else }}
+          value: "{{ .Values.postgresql.username }}"
+          {{- end }}
+        - name: CAMUNDA_JDBC_PASSWORD
+          {{- if and .Values.postgresql.externalSecret .Values.postgresql.externalSecret.name .Values.postgresql.externalSecret.passwordKey }}
+          valueFrom:
+            configMapKeyRef:
+              key: {{ .Values.postgresql.externalSecret.passwordKey }}
+              name: "{{ .Values.postgresql.externalSecret.name }}"
+          {{- else }}
+          value: "{{ .Values.postgresql.password }}"
+          {{- end }}
         - name: CAMUNDA_DATABASE_NAME
-          valueFrom:
-            configMapKeyRef:
-              key: CAMUNDA_DATABASE_NAME
-              name: "{{ .Chart.Name }}"
+          value: "{{ .Values.postgresql.database }}"
         - name: CAMUNDA_DATABASE_PORT
-          valueFrom:
-            configMapKeyRef:
-              key: CAMUNDA_DATABASE_PORT
-              name: "{{ .Chart.Name }}"
+          value: "{{ .Values.postgresql.port }}"
         - name: CAMUNDA_DATABASE_SERVICE_NAME
-          valueFrom:
-            configMapKeyRef:
-              key: DATABASE_SERVICE_NAME
-              name: "{{ .Values.formsflow.configmap }}"
+          value: "{{ .Values.postgresql.host }}"
+        - name: CAMUNDA_JDBC_URL
+          value: "jdbc:postgresql://@${CAMUNDA_DATABASE_SERVICE_NAME}:${CAMUNDA_DATABASE_PORT}/${CAMUNDA_DATABASE_NAME}"
         - name: KEYCLOAK_URL
           valueFrom:
             configMapKeyRef:

--- a/charts/forms-flow-bpm/templates/secret.yaml
+++ b/charts/forms-flow-bpm/templates/secret.yaml
@@ -6,6 +6,5 @@ metadata:
     app: "{{ .Chart.Name }}"
   name: "{{ .Chart.Name }}"
 stringData:
-  CAMUNDA_JDBC_PASSWORD: "{{ .Values.camunda.jdbc.password }}"
   CAMUNDA_FORMBUILDER_PIPELINE_PASSWORD: "{{ .Values.camunda.formBuilder.password }}"
 

--- a/charts/forms-flow-bpm/values.yaml
+++ b/charts/forms-flow-bpm/values.yaml
@@ -1,13 +1,25 @@
 Domain: #<DEFINE_ME>
+
+postgresql:
+  host: forms-flow-ai-postgresql-ha-pgpool
+  port: 5432
+
+  jdbcDriver: org.postgresql.Driver
+  database: forms-flow-bpm
+
+  username: postgres
+  password: postgres
+
+  externalSecret:
+    name: 
+    usernameKey: username
+    passwordKey: password
+
 camunda:
-  analytics:
-    database: forms-flow-analytics
   auth:
     enabled: true
     revokeCheck: auto
-  database:
-    name: forms-flow-bpm
-    port: 5432
+
   historyLevel: auto
   securityOrigin: '*'
   logLevel: INFO
@@ -21,11 +33,6 @@ camunda:
       valid: 5000 #CAMUNDA_HIKARI_VALID_TIMEOUT
     poolsize:
       max: 10 #CAMUNDA_HIKARI_MAX_POOLSIZE
-  jdbc:
-    driver: org.postgresql.Driver
-    username: postgres
-    password: postgres
-    url: "jdbc:postgresql://${CAMUNDA_DATABASE_SERVICE_NAME}:${CAMUNDA_DATABASE_PORT}/${CAMUNDA_DATABASE_NAME}"
   websocket:
     messageType: TASK_EVENT #WEBSOCKET_MESSAGE_TYPE
     securityOrigin:   #WEBSOCKET_SECURITY_ORIGIN
@@ -49,6 +56,7 @@ ingress:
   selfSigned: false
   extraTls:
    - {}
+
 mail:
   from: "<DEFINE_ME>"
   password: "<DEFINE_ME>"

--- a/charts/forms-flow-idm/Chart.yaml
+++ b/charts/forms-flow-idm/Chart.yaml
@@ -9,4 +9,5 @@ dependencies:
   - name: postgresql-ha 
     repository: https://charts.bitnami.com/bitnami
     version: 10.0.9
+    condition: postgresql-ha.enabled
 icon: "https://raw.githubusercontent.com/AOT-Technologies/forms-flow-ai/develop/.images/logo.png"

--- a/charts/forms-flow-idm/templates/configmap.yaml
+++ b/charts/forms-flow-idm/templates/configmap.yaml
@@ -11,7 +11,7 @@ data:
       "revokeRefreshToken": false,
       "refreshTokenMaxReuse": 0,
       "accessTokenLifespan": 300,
-      "accessTokeLifespanForImplicitFlow": 900,
+      "accessTokenLifespanForImplicitFlow": 900,
       "ssoSessionIdleTimeout": 1800,
       "ssoSessionMaxLifespan": 36000,
       "ssoSessionIdleTimeoutRememberMe": 0,

--- a/charts/forms-flow-idm/templates/configmap.yaml
+++ b/charts/forms-flow-idm/templates/configmap.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
     name: "forms-flow-idm"
 data:
-  "realm.json": |- 
+  "realm.json": |-
     {
       "id": "forms-flow-ai",
       "realm": "forms-flow-ai",
@@ -11,7 +11,7 @@ data:
       "revokeRefreshToken": false,
       "refreshTokenMaxReuse": 0,
       "accessTokenLifespan": 300,
-      "accessTokenLifespanForImplicitFlow": 900,
+      "accessTokeLifespanForImplicitFlow": 900,
       "ssoSessionIdleTimeout": 1800,
       "ssoSessionMaxLifespan": 36000,
       "ssoSessionIdleTimeoutRememberMe": 0,
@@ -268,6 +268,14 @@ data:
               "attributes": {}
             },
             {
+              "name": "formsflow-admin",
+              "description": "Provides admin access to use the formsflow.ai solution. Required to manage users and permissions.",
+              "composite": false,
+              "clientRole": true,
+              
+              "attributes": {}
+            },
+            {
               "name": "formsflow-designer",
               "description": "Provides access to use the formsflow.ai solution. Access to wok on form designer studio.",
               "composite": false,
@@ -278,14 +286,6 @@ data:
             {
               "name": "formsflow-reviewer",
               "description": "Provides access to use the formsflow.ai solution. Identifies the staff to work on applications and forms submissions.",
-              "composite": false,
-              "clientRole": true,
-              
-              "attributes": {}
-            },
-            {
-              "name": "formsflow-analytics",
-              "description": "",
               "composite": false,
               "clientRole": true,
               
@@ -402,6 +402,18 @@ data:
               "subGroups": []
             },
             {
+              "name": "formsflow-admin",
+              "path": "/formsflow/formsflow-admin",
+              "attributes": {},
+              "realmRoles": [],
+              "clientRoles": {
+                "forms-flow-web": [
+                  "formsflow-admin"
+                ]
+              },
+              "subGroups": []
+            },
+            {
               "name": "formsflow-designer",
               "path": "/formsflow/formsflow-designer",
               "attributes": {},
@@ -423,24 +435,49 @@ data:
                   "formsflow-reviewer"
                 ]
               },
-          "subGroups": [
-          {
-            "name": "clerk",
-            "path": "/formsflow/formsflow-reviewer/clerk",
-            "attributes": {},
-            "realmRoles": [],
-            "clientRoles": {},
-            "subGroups": []
-          },
-          {
-            "name": "approver",
-            "path": "/formsflow/formsflow-reviewer/approver",
-            "attributes": {},
-            "realmRoles": [],
-            "clientRoles": {},
-            "subGroups": []
-          }
+              "subGroups": [
+                {
+                    "name": "clerk",
+                    "path": "/formsflow/formsflow-reviewer/clerk",
+                    "attributes": {},
+                    "realmRoles": [],
+                    "clientRoles": {},
+                    "subGroups": []
+                },
+                {
+                    "name": "approver",
+                    "path": "/formsflow/formsflow-reviewer/approver",
+                    "attributes": {},
+                    "realmRoles": [],
+                    "clientRoles": {},
+                    "subGroups": []
+                }
+              ]
+            }
           ]
+        },
+        {
+          "name": "formsflow-analytics",
+          "path": "/formsflow-analytics",
+          "attributes": {},
+          "realmRoles": [],
+          "clientRoles": {},
+          "subGroups": [
+            {
+              "name": "group2",
+              "path": "/formsflow-analytics/group2",
+              "attributes": {},
+              "realmRoles": [],
+              "clientRoles": {},
+              "subGroups": []
+            },
+            {
+              "name": "group1",
+              "path": "/formsflow-analytics/group1",
+              "attributes": {},
+              "realmRoles": [],
+              "clientRoles": {},
+              "subGroups": []
             }
           ]
         }
@@ -451,7 +488,8 @@ data:
       ],
       "defaultGroups": [
         "/camunda-admin",
-        "/formsflow"
+        "/formsflow",
+        "/formsflow-analytics"
       ],
       "requiredCredentials": [
         "password"
@@ -513,6 +551,30 @@ data:
         },
         "notBefore" : 0,
         "groups" : [ "/camunda-admin", "/formsflow/formsflow-client" ]
+      },
+      {
+        "createdTimestamp" : 1621862607660,
+        "username" : "formsflow-admin",
+        "enabled" : true,
+        "totp" : false,
+        "emailVerified" : false,
+        "firstName" : "Admin",
+        "lastName" : "FFA",
+        "email" : "formsflow-admin@example.com",
+        "credentials" : [ {
+          "type" : "password",
+          "createdDate" : 1621863987325,
+          "secretData" : "{\"value\":\"9R9a8Onha7JcZt59SIq8ngfqwDJwPKiKb8mJ2WO6p2eI3S9qhzR1GPDFtKjOWq8qpm8vsGfp/a/DyHWQuIvmlA==\",\"salt\":\"R/OTBeSXHzsKtJOV/bufEA==\"}",
+          "credentialData" : "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\"}"
+        } ],
+        "disableableCredentialTypes" : [ ],
+        "requiredActions" : [ "UPDATE_PASSWORD" ],
+        "realmRoles" : [ "uma_authorization", "offline_access" ],
+        "clientRoles" : {
+          "account" : [ "view-profile", "manage-account" ]
+        },
+        "notBefore" : 0,
+        "groups" : [ "/camunda-admin", "/formsflow/formsflow-admin" ]
       }, {
         "createdTimestamp" : 1621862546931,
         "username" : "formsflow-designer",
@@ -535,7 +597,7 @@ data:
           "account" : [ "view-profile", "manage-account" ]
         },
         "notBefore" : 0,
-        "groups" : [ "/camunda-admin", "/formsflow/formsflow-designer" ]
+        "groups" : [ "/camunda-admin", "/formsflow/formsflow-designer", "/formsflow/formsflow-admin" ]
       }, {
         "createdTimestamp" : 1625009614956,
         "username" : "formsflow-approver",
@@ -554,7 +616,7 @@ data:
         "disableableCredentialTypes" : [ ],
         "requiredActions" : [ "UPDATE_PASSWORD" ],
         "notBefore" : 0,
-        "groups" : [ "/formsflow/formsflow-reviewer/approver", "/camunda-admin", "/formsflow" ]
+        "groups" : [ "/formsflow/formsflow-reviewer/approver", "/camunda-admin", "/formsflow" , "/formsflow-analytics/group1"]
       }, {
         "createdTimestamp" : 1625009564217,
         "username" : "formsflow-clerk",
@@ -573,7 +635,7 @@ data:
         "disableableCredentialTypes" : [ ],
         "requiredActions" : [ "UPDATE_PASSWORD" ],
         "notBefore" : 0,
-        "groups" : [ "/camunda-admin", "/formsflow/formsflow-reviewer/clerk", "/formsflow" ]
+        "groups" : [ "/camunda-admin", "/formsflow/formsflow-reviewer/clerk", "/formsflow", "/formsflow-analytics/group2" ]
       }, {
         "createdTimestamp" : 1621862578318,
         "username" : "formsflow-reviewer",
@@ -596,7 +658,7 @@ data:
           "account" : [ "view-profile", "manage-account" ]
         },
         "notBefore" : 0,
-        "groups" : [ "/camunda-admin", "/formsflow/formsflow-reviewer" ]
+        "groups" : [ "/camunda-admin", "/formsflow/formsflow-reviewer", "/formsflow-analytics/group1" ]
       }, {
         "createdTimestamp" : 1621585233480,
         "username" : "service-account-forms-flow-bpm",
@@ -609,7 +671,7 @@ data:
         "requiredActions" : [ ],
         "realmRoles" : [ "uma_authorization", "offline_access" ],
         "clientRoles" : {
-          "realm-management" : [ "query-users", "query-groups", "view-users", "view-clients" ],
+          "realm-management" : [ "manage-users", "query-users", "query-groups", "view-users" , "manage-clients"],
           "account" : [ "view-profile", "manage-account" ]
         },
         "notBefore" : 0,
@@ -804,14 +866,14 @@ data:
         {
           "clientId": "forms-flow-analytics",
           "description": "Redash-Analytics",
-          "adminUrl": "http://localhost:7000/saml/callback?org_slug=default",
+          "adminUrl": "http://localhost:7001/saml/callback?org_slug=default",
           "surrogateAuthRequired": false,
           "enabled": true,
           "alwaysDisplayInConsole": false,
           "clientAuthenticatorType": "client-secret",
           "secret": "**********",
           "redirectUris": [
-          "http://localhost:7000/*",
+            "http://localhost:7001/*",
             "*"
           ],
           "webOrigins": [],
@@ -891,9 +953,9 @@ data:
           "enabled": true,
           "alwaysDisplayInConsole": false,
           "clientAuthenticatorType": "client-secret",
-          "secret":  "786001d6-68a8-4519-903c-bc5b5a870d68",
+          "secret": "{{.Values.keycloak.clientSecrets.bpm}}",
           "redirectUris": [
-          "http://localhost:8000/camunda/*",
+            "http://localhost:8000/camunda/*",
             "*"
           ],
           "webOrigins": [
@@ -968,7 +1030,7 @@ data:
                 "jsonType.label": "String"
               }
             },
-        {
+            {
               "name": "camunda-rest-api",
               "protocol": "openid-connect",
               "protocolMapper": "oidc-audience-mapper",
@@ -1045,7 +1107,7 @@ data:
           "clientAuthenticatorType": "client-secret",
           "secret": "**********",
           "redirectUris": [
-          "http://localhost:3000/*",
+            "http://localhost:3000/*",
             "*"
           ],
           "webOrigins": [
@@ -1114,6 +1176,21 @@ data:
                 "access.token.claim": "true",
                 "claim.name": "groups",
                 "userinfo.token.claim": "true"
+              }
+            },
+            {
+              "name": "dashboard-mapper",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usermodel-attribute-mapper",
+              "consentRequired": false,
+              "config": {
+                "aggregate.attrs": "true",
+                "userinfo.token.claim": "true",
+                "multivalued": "true",
+                "user.attribute": "dashboards",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "dashboards"
               }
             }
           ],

--- a/charts/forms-flow-idm/values.yaml
+++ b/charts/forms-flow-idm/values.yaml
@@ -1,5 +1,7 @@
 ---
 keycloak:
+  clientSecrets:
+    bpm: "e4bdbd25-1467-4f7f-b993-bc4b1944c943"
   auth:
     adminUser: admin
   tls:


### PR DESCRIPTION
Hi,

we've refactored the helm chart in order to support external postgres databases and to streamline the database configuration. This allows e.g. the usage of the postgres operator.

In addition we've removed some other hardcoded configuration, such that is available in the `values.yaml`.

We also added the new realm export for 5.2.0, such that all permissions are set correctly.

Feel free to give any feedback or suggestions.

Best
Daniel